### PR TITLE
chore: trunk ignore changelog due to release-plz

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -34,6 +34,10 @@ lint:
     - linters: [tofu]
       paths:
         - "**/backend.tf.json"
+    # Ignore CHANGELOG.md as release-please manages this file
+    - linters: [prettier, markdownlint]
+      paths:
+        - CHANGELOG.md
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
## what

- Adds changelog to be ignored by trunk

## why

- Release-please manages our changelog and trunk will fail because release-please isn't following prettier or markdownlint rules

## references

- See https://github.com/masterpointio/terraform-spacelift-automation/pull/10 for where this originally came up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an ignore rule for linters on the `CHANGELOG.md` file to streamline management.
  
- **Documentation**
	- Updated configuration file to reflect the new ignore rule for specific linters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->