### PR TITLE
feat(renovate): enables renovate terraform manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,29 @@
+{
+  "extends": [
+    "config:best-practices",
+    "github>aquaproj/aqua-renovate-config#2.7.5"
+  ],
+  "schedule": [
+    "every month"
+  ],
+  "assigneesFromCodeOwners": true,
+  "dependencyDashboardAutoclose": true,
+  "addLabels": [
+    "auto-upgrade"
+  ],
+  "enabledManagers": [
+    "terraform"
+  ],
+  "terraform": {
+    "ignorePaths": [
+      "**/context.tf" // Mixin file https://github.com/cloudposse/terraform-null-label/blob/main/exports/context.tf
+    ]
+  },
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "optionalDependencies"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## what
* Update Renovate configuration to extend from `config:best-practices` and the external preset `github>aquaproj/aqua-renovate-config`.
* Set the schedule to run dependency updates every month.
* Enable automatic PR labeling with `auto-upgrade`.
* Configure PR assignments to be derived from CODEOWNERS.
* Enable automatic closing of the dependency dashboard when no actionable updates remain.

## why
* Scheduling updates monthly keeps the update process streamlined.

## references

* [Renovate Configuration Options Documentation](https://docs.renovatebot.com/configuration-options/)
* GH issue with some background on `config:best-practices` - https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/67