### PR TITLE
fix(renovate): schedule update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
     "github>aquaproj/aqua-renovate-config#2.7.5"
   ],
   "schedule": [
-    "every month on the first day of the month"
+    "after 9am on the first day of the month"
   ],
   "assigneesFromCodeOwners": true,
   "dependencyDashboardAutoclose": true,


### PR DESCRIPTION
## what

- Update `later` schedule syntax to fix `Invalid schedule: Failed to parse "every month on the first day of the month"`

## why

- Renovate is not happy.

## references

- Closes #19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Refined the scheduling for automated dependency tasks to run precisely at 09:00 on the 1st day of every month.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->