### PR TITLE
feat: setup connection to notion db

### DIFF
--- a/.github/workflows/notion-sync.yaml
+++ b/.github/workflows/notion-sync.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Add GitHub Issues to Notion
     steps:
       - name: Add GitHub Issues to Notion
-        uses: tryfabric/notion-github-action@v1
+        uses: tryfabric/notion-github-action@10c6b128faeb9a1f16efc65a0b388b7595047e62
         with:
           notion-token: ${{ secrets.GH_ISSUES_NOTION_TOKEN }}
           notion-db: ${{ secrets.GH_ISSUES_DB_ID }}

--- a/.github/workflows/notion-sync.yaml
+++ b/.github/workflows/notion-sync.yaml
@@ -1,19 +1,10 @@
 name: Notion Sync
 
+permissions:
+  issues: read
+
 on:
   workflow_dispatch:
-  prs:
-    types:
-      - opened
-      - edited
-      - labeled
-      - unlabeled
-      - assigned
-      - unassigned
-      - milestoned
-      - demilestoned
-      - reopened
-      - closed
   issues:
     types:
       - opened

--- a/.github/workflows/notion-sync.yaml
+++ b/.github/workflows/notion-sync.yaml
@@ -2,20 +2,30 @@ name: Notion Sync
 
 on:
   workflow_dispatch:
+  prs:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+      - milestoned
+      - demilestoned
+      - reopened
+      - closed
   issues:
     types:
-      [
-        opened,
-        edited,
-        labeled,
-        unlabeled,
-        assigned,
-        unassigned,
-        milestoned,
-        demilestoned,
-        reopened,
-        closed,
-      ]
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+      - milestoned
+      - demilestoned
+      - reopened
+      - closed
 
 jobs:
   notion_job:

--- a/.github/workflows/notion-sync.yaml
+++ b/.github/workflows/notion-sync.yaml
@@ -1,0 +1,29 @@
+name: Notion Sync
+
+on:
+  workflow_dispatch:
+  issues:
+    types:
+      [
+        opened,
+        edited,
+        labeled,
+        unlabeled,
+        assigned,
+        unassigned,
+        milestoned,
+        demilestoned,
+        reopened,
+        closed,
+      ]
+
+jobs:
+  notion_job:
+    runs-on: ubuntu-latest
+    name: Add GitHub Issues to Notion
+    steps:
+      - name: Add GitHub Issues to Notion
+        uses: tryfabric/notion-github-action@v1
+        with:
+          notion-token: ${{ secrets.GH_ISSUES_NOTION_TOKEN }}
+          notion-db: ${{ secrets.GH_ISSUES_DB_ID }}


### PR DESCRIPTION
## what

- following the [Notion x GitHub Action GHA setup instructions](https://github.com/marketplace/actions/notion-x-github-action), let's connect this repo's issues and the [Masterpointio Github Issues page](https://www.notion.so/masterpoint/17b859758a56806a9000ff4bc2bde8b4?v=17b859758a56817ca64c000c1b6b471d)

## references
- let's see if this expression, `closes #INT-52`, closes the issue [INT-52](https://www.notion.so/masterpoint/Create-automation-for-Masterpoint-GH-issues-creating-Notion-tickets-auto-assign-to-a-team-member--c51a716979fe44f7a0163a1c3353f9ef)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated integration that syncs issue updates with Notion. This enhancement triggers on various issue actions—such as creation, updates, and status changes—ensuring streamlined tracking and improved workflow management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->