### PR TITLE
feat: upgrade terraform docs

### DIFF
--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,4 +1,4 @@
-version: 0.19.0
+version: 0.20.0
 formatter: markdown table
 
 recursive:

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -10,6 +10,6 @@ registries:
   - type: standard
     ref: v4.210.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: terraform-docs/terraform-docs@v0.19.0
+  - name: terraform-docs/terraform-docs@v0.20.0
   - name: hashicorp/terraform@v1.9.3
   - name: opentofu/opentofu@v1.8.0


### PR DESCRIPTION
## what

- upgrade terraform docs to 0.20.0

## references

- https://github.com/masterpointio/terraform-postgres-admin/pull/1#discussion_r2056618895


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the terraform-docs tool and its configuration to version 0.20.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->