### PR TITLE
chore: configure renovate to update opentofu itself, modules and providers

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,10 @@
   "terraform": {
     "ignorePaths": [
       "**/context.tf" // Mixin file https://github.com/cloudposse/terraform-null-label/blob/main/exports/context.tf
+    ],
+    "fileMatch": [
+      "**/*.tf",
+      "**/*.tofu"
     ]
   },
   "packageRules": [
@@ -32,6 +36,21 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "matchFiles": ["**/*.tofu", "**/*.tf"],
+      "matchDatasources": ["terraform-provider", "terraform-module"],
+      "registryUrls": ["https://registry.opentofu.org"]
+    },
+    {
+      "matchFiles": ["**/*.tofu"],
+      "matchDepTypes": ["required_version"],
+      "registryUrls": ["https://registry.opentofu.org"]
+    },
+    {
+      "matchFiles": ["**/*.tf"],
+      "matchDepTypes": ["required_version"],
+      "registryUrls": ["https://registry.terraform.io"]
     }
   ]
 }

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,9 +20,10 @@ lint:
     # Incompatible with some Terraform features: https://github.com/tenable/terrascan/issues/1331
     - terrascan
   enabled:
+    - renovate@39.263.0
     - tofu@1.9.1
     - actionlint@1.7.7
-    - checkov@3.2.408
+    - checkov@3.2.412
     - git-diff-check
     - markdownlint@0.44.0
     - prettier@3.5.3

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,7 +8,7 @@
 #   - all
 registries:
   - type: standard
-    ref: v4.353.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.355.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: terraform-docs/terraform-docs@v0.20.0
   - name: hashicorp/terraform@v1.11.4


### PR DESCRIPTION
## what

These package rules will:
- Match both terraform providers and modules (matchDatasources)
- Use OpenTofu's registry URL (https://registry.opentofu.org) instead of the default Terraform registry
- This configuration will make Renovate look for updates in the OpenTofu registry for both providers and modules. 
- This supports updating both Terraform and OpenTofu:
    - `versions.tofu` file will be updated using the OpenTofu registry
    - `versions.tf` file will be updated using the Terraform registry
    - Providers and modules in `*.tf` and `*.tofu` files will be updated using the OpenTofu registry

## why

- Easier TF upgrades.

## references

- [INT-5003](https://www.notion.so/masterpoint/Investigate-renovate-aqua-atmos-plugin-for-easy-tofu-upgrades-8267e0592e4b497d8d0d996e29f8b760?pvs=4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Renovate configuration to support `.tofu` files and OpenTofu registry.
  - Added and upgraded linters in the lint configuration, including the latest Renovate linter and a newer version of Checkov.
  - Updated the standard registry version in the package management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->