### PR TITLE
chore: rename attribute

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,17 +38,17 @@
       "automerge": true
     },
     {
-      "matchFiles": ["**/*.tofu", "**/*.tf"],
+      "matchFileNames": ["**/*.tofu", "**/*.tf"],
       "matchDatasources": ["terraform-provider", "terraform-module"],
       "registryUrls": ["https://registry.opentofu.org"]
     },
     {
-      "matchFiles": ["**/*.tofu"],
+      "matchFileNames": ["**/*.tofu"],
       "matchDepTypes": ["required_version"],
       "registryUrls": ["https://registry.opentofu.org"]
     },
     {
-      "matchFiles": ["**/*.tf"],
+      "matchFileNames": ["**/*.tf"],
       "matchDepTypes": ["required_version"],
       "registryUrls": ["https://registry.terraform.io"]
     }


### PR DESCRIPTION
## what

- [matchfilenames](https://docs.renovatebot.com/configuration-options/#matchfilenames) should fix this issue:
```
There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Location: .github/renovate.json5
Error type: The renovate configuration file contains some invalid settings
Message: Invalid regExp for terraform.fileMatch: **/*.tf, Invalid regExp for terraform.fileMatch: **/*.tofu
```

## why

- I break things.

## references

- https://github.com/masterpointio/terraform-module-template/issues/19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration for dependency management; no impact on end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->