### PR TITLE
feat(gha): oidc aws credentials if AWS provider is used

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Trunk Check
-        uses: trunk-io/trunk-action@v1
+        uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,20 +45,20 @@ jobs:
         run: aqua install --tags ${{ matrix.tf }}
 
       - name: Check if TF AWS provider is used
-        id: check_hashicorp
+        id: check_aws_provider
         run: |
-          if grep -q "hashicorp/aws" $(find . -name "*.tf" -o -name "*.tofu" -type f); then
-            echo "Found hashicorp/aws in .tf or .tofu files"
+          if grep -q "aws" $(find . -name "versions.tf" -o -name "versions.tofu" -type f); then
+            echo "Found aws in versions.tf or versions.tofu files"
             echo "contains_hashicorp=true" >> $GITHUB_OUTPUT
           else
-            echo "No .tf or .tofu files contain hashicorp/aws"
+            echo "No versions.tf or versions.tofu files contain aws"
             echo "contains_hashicorp=false" >> $GITHUB_OUTPUT
           fi
 
       # Assume into the `masterpoint-testing` AWS account with OIDC for testing ONLY if the AWS provider is used
       # Not needed for modules that don't use the AWS provider, for example, exclusive Spacelift modules
       - name: Configure AWS Credentials on `masterpoint-testing` AWS Account
-        if: steps.check_hashicorp.outputs.contains_hashicorp == 'true'
+        if: steps.check_aws_provider.outputs.contains_hashicorp == 'true'
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: arn:aws:iam::115843287071:role/mp-ue1-testing-oidc-github

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,11 +47,11 @@ jobs:
       - name: Check if TF AWS provider is used
         id: check_hashicorp
         run: |
-          if grep -q "hashicorp/aws" $(find . -name "*.tf" -type f); then
-            echo "Found hashicorp/aws in .tf files"
+          if grep -q "hashicorp/aws" $(find . -name "*.tf" -o -name "*.tofu" -type f); then
+            echo "Found hashicorp/aws in .tf or .tofu files"
             echo "contains_hashicorp=true" >> $GITHUB_OUTPUT
           else
-            echo "No .tf files contain hashicorp/aws"
+            echo "No .tf or .tofu files contain hashicorp/aws"
             echo "contains_hashicorp=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,11 +44,11 @@ jobs:
       - name: Check if TF AWS provider is used
         id: check_hashicorp
         run: |
-          if grep -q "hashicorp/aws" $(find . -type f -not -path "*/\.git/*"); then
-            echo "Found hashicorp/aws in repository files"
+          if grep -q "hashicorp/aws" $(find . -name "*.tf" -type f); then
+            echo "Found hashicorp/aws in .tf files"
             echo "contains_hashicorp=true" >> $GITHUB_OUTPUT
           else
-            echo "No files contain hashicorp/aws"
+            echo "No .tf files contain hashicorp/aws"
             echo "contains_hashicorp=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,5 +41,24 @@ jobs:
         shell: bash
         run: aqua install --tags ${{ matrix.tf }}
 
+      - name: Check if TF AWS provider is used
+        id: check_hashicorp
+        run: |
+          if grep -q "hashicorp/aws" $(find . -type f -not -path "*/\.git/*"); then
+            echo "Found hashicorp/aws in repository files"
+            echo "contains_hashicorp=true" >> $GITHUB_OUTPUT
+          else
+            echo "No files contain hashicorp/aws"
+            echo "contains_hashicorp=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS Credentials on `masterpoint-testing` AWS Account
+        if: steps.check_hashicorp.outputs.contains_hashicorp == 'true'
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::115843287071:role/mp-ue1-testing-oidc-github
+          role-session-name: GitHubActionsOIDC-MP-Infra-Repo
+          aws-region: ${{ env.AWS_REGION }}
+
       - run: ${{ matrix.tf }} init
       - run: ${{ matrix.tf }} test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,8 @@ jobs:
             echo "contains_hashicorp=false" >> $GITHUB_OUTPUT
           fi
 
+      # Assume into the `masterpoint-testing` AWS account with OIDC for testing ONLY if the AWS provider is used
+      # Not needed for modules that don't use the AWS provider, for example, exclusive Spacelift modules
       - name: Configure AWS Credentials on `masterpoint-testing` AWS Account
         if: steps.check_hashicorp.outputs.contains_hashicorp == 'true'
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ permissions:
   id-token: write
   pull-requests: read
 
+env:
+  AWS_REGION: us-east-1
+
 jobs:
   tf-test:
     name: 🧪 ${{ matrix.tf }} test

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0"
     }
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.0"
-    }
   }
 }


### PR DESCRIPTION
GitHub Actions conditionally assume into the `masterpoint-testing` AWS account for native Terraform tests, ONLY if the AWS provider is used. 

Some of our modules, for example the Spacelift modules like terraform-spacelift-automation, only uses the Spacelift provider so there is no need to assume into the AWS role.

But others such as Tailscale, in order to perform tests, AWS credentials are needed, even for unit tests (TF plans). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow to automatically detect AWS provider usage and configure AWS credentials as needed during testing.
- **New Features**
	- Added AWS provider to the Terraform configuration, enabling AWS resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->