### PR TITLE
fix(renovate): valid regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,8 +19,8 @@
       "**/context.tf" // Mixin file https://github.com/cloudposse/terraform-null-label/blob/main/exports/context.tf
     ],
     "fileMatch": [
-      "**/*.tf",
-      "**/*.tofu"
+      "\\.tf$",
+      "\\.tofu$"
     ]
   },
   "packageRules": [


### PR DESCRIPTION
## what

- For `fileMatch`, we should use regex pattern, not globbing.
- I'm confused why trunk check didn't fail for previous PR, because this obviously is an issue:
```
❯ trunk check .github/renovate.json5 --show-existing 
Checking 100% [==================================================>]  16/16  1.4s 
                                                                                 
  ISSUES  

.github/renovate.json5:0:0
 0:0  high  Invalid regExp for terraform.fileMatch:  renovate/Configuration-Error
            `**/*.tofu`                                                        

Checked 1 file
1 existing issue
✔ No new issues
```

## why

- Confusing, but this is how it works in renovate.

## references

- https://github.com/masterpointio/terraform-module-template/issues/19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the way Terraform files are identified for automated dependency updates, improving file matching accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->