### PR TITLE
feat: GHA, trunk and renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,8 +28,14 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeType": "branch",
-      "groupName": "github-actions",
+      "groupName": "github-actions-auto-upgrade",
       "addLabels": ["auto-upgrade"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github-actions-needs-review",
+      "addLabels": ["needs-review"]
     },
     {
       "matchManagers": ["terraform"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,16 +3,9 @@
     "config:best-practices",
     "github>aquaproj/aqua-renovate-config#2.7.5"
   ],
-  "schedule": [
-    "after 9am on the first day of the month"
-  ],
-  "assigneesFromCodeOwners": true,
-  "dependencyDashboardAutoclose": true,
-  "addLabels": [
-    "auto-upgrade"
-  ],
   "enabledManagers": [
-    "terraform"
+    "terraform",
+    "github-actions"
   ],
   "terraform": {
     "ignorePaths": [
@@ -23,34 +16,43 @@
       "\\.tofu$"
     ]
   },
+  "schedule": [
+    "after 9am on the first day of the month"
+  ],
+  "assigneesFromCodeOwners": true,
+  "dependencyDashboardAutoclose": true,
+  "addLabels": ["{{manager}}"],
   "packageRules": [
     {
-      "matchDepTypes": [
-        "optionalDependencies"
-      ],
-      // Allow auto merge if it's not a major version update
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "automerge": true
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch",
+      "groupName": "github-actions",
+      "addLabels": ["auto-upgrade"]
+    },
+    {
+      "matchManagers": ["terraform"],
+      "groupName": "tf",
+      "addLabels": ["needs-review"]
     },
     {
       "matchFileNames": ["**/*.tofu", "**/*.tf"],
       "matchDatasources": ["terraform-provider", "terraform-module"],
-      "registryUrls": ["https://registry.opentofu.org"]
+      "registryUrls": ["https://registry.opentofu.org"],
+      "groupName": "tf"
     },
     {
       "matchFileNames": ["**/*.tofu"],
       "matchDepTypes": ["required_version"],
-      "registryUrls": ["https://registry.opentofu.org"]
+      "registryUrls": ["https://registry.opentofu.org"],
+      "groupName": "tf"
     },
     {
       "matchFileNames": ["**/*.tf"],
       "matchDepTypes": ["required_version"],
-      "registryUrls": ["https://registry.terraform.io"]
+      "registryUrls": ["https://registry.terraform.io"],
+      "groupName": "tf"
     }
   ]
 }

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/int-66/gha-and-renovate-updates
   pull_request:
 
 permissions:
@@ -13,9 +14,6 @@ permissions:
   id-token: write
   pull-requests: read
 
-env:
-  AWS_REGION: us-east-1
-
 jobs:
   tf-test:
     name: 🧪 ${{ matrix.tf }} test
@@ -24,46 +22,7 @@ jobs:
       matrix:
         tf: [tofu, terraform]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Aqua Cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        if: ${{ !github.event.act }} # Don't enable the cache step if we're using act for testing
+      - uses: masterpointio/github-action-tf-test@c3b619f3bca9e4f482b9e0fb3166ab3f02d9d54c # v1.0.0
         with:
-          path: ~/.local/share/aquaproj-aqua
-          key: v1-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
-          restore-keys: |
-            v1-aqua-installer-${{runner.os}}-${{runner.arch}}-
-
-      - name: Install Aqua
-        uses: aquaproj/aqua-installer@5e54e5cee8a95ee2ce7c04cb993da6dfad13e59c # v3.2.1
-        with:
-          aqua_version: v2.48.1
-
-      - name: Aqua Install
-        shell: bash
-        run: aqua install --tags ${{ matrix.tf }}
-
-      - name: Check if TF AWS provider is used
-        id: check_aws_provider
-        run: |
-          if grep -q "aws" $(find . -name "versions.tf" -o -name "versions.tofu" -type f); then
-            echo "Found aws in versions.tf or versions.tofu files"
-            echo "contains_hashicorp=true" >> $GITHUB_OUTPUT
-          else
-            echo "No versions.tf or versions.tofu files contain aws"
-            echo "contains_hashicorp=false" >> $GITHUB_OUTPUT
-          fi
-
-      # Assume into the `masterpoint-testing` AWS account with OIDC for testing ONLY if the AWS provider is used
-      # Not needed for modules that don't use the AWS provider, for example, exclusive Spacelift modules
-      - name: Configure AWS Credentials on `masterpoint-testing` AWS Account
-        if: steps.check_aws_provider.outputs.contains_hashicorp == 'true'
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        with:
-          role-to-assume: arn:aws:iam::115843287071:role/mp-ue1-testing-oidc-github
-          role-session-name: GitHubActionsOIDC-MP-Infra-Repo
-          aws-region: ${{ env.AWS_REGION }}
-
-      - run: ${{ matrix.tf }} init
-      - run: ${{ matrix.tf }} test
+          tf_type: ${{ matrix.tf }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/int-66/gha-and-renovate-updates
   pull_request:
 
 permissions:
@@ -25,4 +24,5 @@ jobs:
       - uses: masterpointio/github-action-tf-test@c3b619f3bca9e4f482b9e0fb3166ab3f02d9d54c # v1.0.0
         with:
           tf_type: ${{ matrix.tf }}
+          aws_role_arn: ${{ vars.TF_TEST_AWS_ROLE_ARN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -27,8 +27,17 @@ jobs:
           private_key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
 
       - name: Upgrade
+        id: trunk-upgrade
         uses: trunk-io/trunk-action/upgrade@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           reviewers: "@masterpointio/masterpoint-internal"
           prefix: "chore: "
+
+      - name: Merge PR automatically
+        if: steps.trunk-upgrade.outputs.pull-request-number != ''
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ steps.trunk-upgrade.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --squash --auto --delete-branch


### PR DESCRIPTION
## what

- Renovate updates:
  - Added github-actions manager
  - Grouped TF and GHA updates to reduce noise (see [the docs](https://docs.renovatebot.com/noise-reduction/))
  - Configured to merge minor GHA updates automatically
  - TF and major GHA updates require review
 
- Test GHA updates:
  - Switched to reusable GHA

- Trunk Upgrade updates:
  - Added a step to merge the PR automatically with a native GH tooling (see [the recommendations from community](https://github.com/peter-evans/enable-pull-request-automerge?tab=readme-ov-file#usage)).
  - GitHub CLI (gh) is pre-installed on ubuntu-latest.
  - `--auto` enables auto-merge, waiting until all required checks have passed.
  - GitHub App already has appropriate permissions: `contents: write`, `pull-requests: write`

## why

- This is a desired behaviour.

## references

- https://masterpoint.slack.com/archives/C04MUCKUDKK/p1746468817883509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management configuration to improve automation for GitHub Actions and Terraform updates, including enhanced grouping and labeling of update PRs.
  - Simplified the test workflow by consolidating multiple steps into a single action for Terraform and Tofu testing.
  - Enhanced the trunk upgrade workflow to automatically merge upgrade pull requests when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->