### PR TITLE
fix: use `pull_request_target` to allow permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 permissions:
   actions: read


### PR DESCRIPTION
Use `pull_request_target` in favor of `pull_request` because of this issue we had outlined in this PR: https://github.com/masterpointio/terraform-aws-ssm-agent/pull/40

PRs created from forks were not able to be ran against the test action because of the GITHUB_TOKEN permissions that was needed. The `pull_request_target` provides that.

We have to manually approve any of those PR's to run the test, so we are covered on the security side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow trigger for automated tests to improve pull request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->