### PR TITLE
fix(gha-lint): allow lint workflow to be triggered by github-actions[bot]

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,7 +4,7 @@ concurrency:
   group: lint-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   actions: read


### PR DESCRIPTION
## what

- Use the `on: pull_request_target` event in lint workflow.

## why

- GitHub Actions workflows configured with `on: pull_request` do not trigger for Pull Requests created by the default github-actions[bot] user. This leads to PRs being "blocked" or "pending checks" indefinitely, _if repository rulesets require those checks._
- pull_request_target runs from the base repository's context, allowing it to be triggered by github-actions[bot].

## references

- Related PR https://github.com/masterpointio/terraform-module-template/pull/37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the trigger for the lint workflow to improve how and when it runs on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->