### PR TITLE
fix(gha-trunk-upgrade): wait for checks and merge with admin

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -34,10 +34,29 @@ jobs:
           reviewers: "@masterpointio/masterpoint-internal"
           prefix: "chore: "
 
-      - name: Merge PR automatically
+      - name: Wait for checks to pass + Merge PR
         if: steps.trunk-upgrade.outputs.pull-request-number != ''
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ steps.trunk-upgrade.outputs.pull-request-number }}
         run: |
-          gh pr merge "$PR_NUMBER" --squash --auto --delete-branch
+          echo "Waiting for required status checks to pass on PR #$PR_NUMBER..."
+          while true; do
+            CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --required --json state,bucket)
+            echo "Current checks status: $CHECKS_JSON"
+
+            if echo "$CHECKS_JSON" | jq -e '.[] | select(.bucket=="fail")' > /dev/null; then
+              echo "One or more required checks have failed. Exiting..."
+              exit 1
+            fi
+
+            FAILED_OR_PENDING_CHECKS=$(echo "$CHECKS_JSON" | jq '[.[] | select(.state!="SUCCESS" or .bucket!="pass")] | length')
+            if [ "$FAILED_OR_PENDING_CHECKS" -eq 0 ]; then
+              echo "All required checks passed. Merging PR https://github.com/${{ github.repository }}/pull/$PR_NUMBER..."
+              gh pr merge "$PR_NUMBER" --squash --delete-branch --admin
+              break
+            else
+              echo "Some required checks are still running or pending. Retrying in 30s..."
+              sleep 30
+            fi
+          done


### PR DESCRIPTION
## what

- Automatically merge PR for trunk upgrade if all required checks have passed:
  - When you add a bot (e.g., Renovate or Trunk) to the bypass list in a GitHub ruleset, it only bypasses certain restrictions, specifically related to:
    - Push restrictions (who can push directly to a protected branch)
    - Force pushes, or bypassing update/deletion rules
  - However, a critical limitation of GitHub rulesets (as of now) is: _rulesets do NOT allow bypassing pull request merge requirements_, such as "Require approval from code owners" or "Require at least one approving review."
  - Thus, the bot can freely open PRs and directly push, but when merging a PR, GitHub explicitly still requires reviews if a ruleset is configured to enforce them, regardless of the bypass settings.
- Successful run of this workflow: https://github.com/masterpointio/terraform-spacelift-automation/actions/runs/15493090377/job/43623096341

## why

- Less manual work.

## references

- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved workflow reliability by ensuring pull requests are only merged after all required status checks have passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->