### PR TITLE
fix(gha): use app–generated token to create release-please PRs

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,6 +14,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Create Token for MasterpointBot App
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.MP_BOT_APP_ID }}
+          private_key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f #v4.1.3
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           release-type: terraform-module


### PR DESCRIPTION
## what

- Configure release-please workflow to create PRs using an App–generated token istead of GITHUB_TOKEN.

## why

- When use the repository’s GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app (the github-actions[bot]), events triggered by that token will not create new workflow runs, with the sole exceptions of workflow_dispatch and repository_dispatch. This is an intentional safeguard to avoid accidental infinite loops of workflows triggering themselves 
[github.com](https://github.com/orgs/community/discussions/26875?utm_source=chatgpt.com).

-  Pull requests created programmatically by the github-actions[bot] (i.e., using GITHUB_TOKEN) do not fire the pull_request event, so any workflow with on: pull_request will not start. Even though the PR appears normally, downstream checks see no trigger and remain stuck, see #43 

## references

- https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
- https://github.com/orgs/community/discussions/26875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release workflow to use a GitHub App token for authentication during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->