### PR TITLE
fix(gha): add auto-approve + update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # Order is important: the last matching pattern takes the most precedence
 
 # These owners will be the default owners for everything
-*             @masterpointio/masterpoint-open-source
+*             @masterpointio/masterpoint-open-source @masterpoint-team

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Wait for checks to pass + Merge PR
         if: steps.trunk-upgrade.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.MASTERPOINT_TEAM_PAT }}
           PR_NUMBER: ${{ steps.trunk-upgrade.outputs.pull-request-number }}
         run: |
           echo "Waiting for required status checks to pass on PR #$PR_NUMBER..."
@@ -52,7 +52,12 @@ jobs:
 
             FAILED_OR_PENDING_CHECKS=$(echo "$CHECKS_JSON" | jq '[.[] | select(.state!="SUCCESS" or .bucket!="pass")] | length')
             if [ "$FAILED_OR_PENDING_CHECKS" -eq 0 ]; then
-              echo "All required checks passed. Merging PR https://github.com/${{ github.repository }}/pull/$PR_NUMBER..."
+              echo "All required checks passed. Auto-approving and merging PR https://github.com/${{ github.repository }}/pull/$PR_NUMBER..."
+
+              # Auto-approve the PR
+              gh pr review "$PR_NUMBER" --approve --body "Auto-approved by trunk upgrade workflow"
+
+              # Merge the PR
               gh pr merge "$PR_NUMBER" --squash --delete-branch --admin
               break
             else


### PR DESCRIPTION
## what

- Auto-approve PRs: Added approval step using MASTERPOINT_TEAM_PAT ([masterpoint-team](https://github.com/orgs/masterpointio/people/masterpoint-team)) before merge
- Updated CODEOWNERS: Added @masterpointio/masterpoint-team as code owners

## why

- Trunk upgrade workflow was failing with "At least 1 approving review is required" error due to Repository Rules enforcement.

## references

- https://github.com/masterpointio/terraform-module-template/actions/runs/15993630429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code owners to include an additional team.
  * Modified workflow to use a different token and added an explicit auto-approval step before merging pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->